### PR TITLE
Color options

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,29 +1,41 @@
 var chalk = require('chalk');
 
-function getChalkColors(configInput) {
+function getChalkColors(defaultConfig, overrideConfig) {
   // make the read file understandable to chalk.
+  var chalkColors = buildChalkFunction(defaultConfig);
+  var overrideChalkColors = buildChalkFunction(overrideConfig);
+  return Object.assign({}, chalkColors, overrideChalkColors);
+}
+
+function buildChalkFunction(config) {
   var chalkColors = {};
-  for (var color in configInput.colors) {
-  	if (configInput.colors.hasOwnProperty(color)) {
-  		var colorFunc = chalk;
-      //build up the chalk function
-      configInput.colors[color].forEach(function(style) {
-  			colorFunc = colorFunc[style];
-  		});
-  		chalkColors[color] = colorFunc;
-  	}
+  for (var color in config.colors) {
+      if (config.colors.hasOwnProperty(color)) {
+        var colorFunc = chalk;
+        //build up the chalk function
+        try {
+          config.colors[color].forEach(function(style) {
+            colorFunc = colorFunc[style];
+          });
+          if (typeof colorFunc === 'undefined') {
+            throw new Error('Unsupported colorFunc');
+          }
+          chalkColors[color] = colorFunc;
+        } catch(err) {
+          console.log(`Error setting style for ${color}. Will use default style.`);
+        }
+      }
   }
   return chalkColors;
 }
 
 var configInput = require("./lmeDefaultConfig.json");
+var providedConfig = {};
 try {
 	// try to get the config file from root file of the application.
-	var providedConfig = require('app-root-path').require("lmeconfig.json");
-  configInput.colors = Object.assign({}, configInput.colors, providedConfig.colors);
+	providedConfig = require('app-root-path').require("lmeconfig.json");
 } catch (e) {
 	//it is okay if no override file is provided
 }
-
-configInput.colors = getChalkColors(configInput);
+configInput.colors = getChalkColors(configInput, providedConfig);
 module.exports = configInput;

--- a/config.js
+++ b/config.js
@@ -10,21 +10,21 @@ function getChalkColors(defaultConfig, overrideConfig) {
 function buildChalkFunction(config) {
 	var chalkColors = {};
 	for (var color in config.colors) {
-			if (config.colors.hasOwnProperty(color)) {
-				var colorFunc = chalk;
-				//build up the chalk function
-				try {
-					config.colors[color].forEach(function(style) {
-						colorFunc = colorFunc[style];
-					});
-					if (typeof colorFunc === 'undefined') {
-						throw new Error('Unsupported colorFunc');
-					}
-					chalkColors[color] = colorFunc;
-				} catch(err) {
-					console.log(`Error setting style for ${color}. Will use default style.`);
+		if (config.colors.hasOwnProperty(color)) {
+			var colorFunc = chalk;
+			//build up the chalk function
+			try {
+				config.colors[color].forEach(function(style) {
+					colorFunc = colorFunc[style];
+				});
+				if (typeof colorFunc === 'undefined') {
+					throw new Error('Unsupported colorFunc');
 				}
+				chalkColors[color] = colorFunc;
+			} catch(err) {
+				console.log(`Error setting style for ${color}. Will use default style.`);
 			}
+		}
 	}
 	return chalkColors;
 }

--- a/config.js
+++ b/config.js
@@ -1,32 +1,32 @@
 var chalk = require('chalk');
 
 function getChalkColors(defaultConfig, overrideConfig) {
-  // make the read file understandable to chalk.
-  var chalkColors = buildChalkFunction(defaultConfig);
-  var overrideChalkColors = buildChalkFunction(overrideConfig);
-  return Object.assign({}, chalkColors, overrideChalkColors);
+	// make the read file understandable to chalk.
+	var chalkColors = buildChalkFunction(defaultConfig);
+	var overrideChalkColors = buildChalkFunction(overrideConfig);
+	return Object.assign({}, chalkColors, overrideChalkColors);
 }
 
 function buildChalkFunction(config) {
-  var chalkColors = {};
-  for (var color in config.colors) {
-      if (config.colors.hasOwnProperty(color)) {
-        var colorFunc = chalk;
-        //build up the chalk function
-        try {
-          config.colors[color].forEach(function(style) {
-            colorFunc = colorFunc[style];
-          });
-          if (typeof colorFunc === 'undefined') {
-            throw new Error('Unsupported colorFunc');
-          }
-          chalkColors[color] = colorFunc;
-        } catch(err) {
-          console.log(`Error setting style for ${color}. Will use default style.`);
-        }
-      }
-  }
-  return chalkColors;
+	var chalkColors = {};
+	for (var color in config.colors) {
+			if (config.colors.hasOwnProperty(color)) {
+				var colorFunc = chalk;
+				//build up the chalk function
+				try {
+					config.colors[color].forEach(function(style) {
+						colorFunc = colorFunc[style];
+					});
+					if (typeof colorFunc === 'undefined') {
+						throw new Error('Unsupported colorFunc');
+					}
+					chalkColors[color] = colorFunc;
+				} catch(err) {
+					console.log(`Error setting style for ${color}. Will use default style.`);
+				}
+			}
+	}
+	return chalkColors;
 }
 
 var configInput = require("./lmeDefaultConfig.json");

--- a/config.js
+++ b/config.js
@@ -1,0 +1,29 @@
+var chalk = require('chalk');
+
+function getChalkColors(configInput) {
+  // make the read file understandable to chalk.
+  var chalkColors = {};
+  for (var color in configInput.colors) {
+  	if (configInput.colors.hasOwnProperty(color)) {
+  		var colorFunc = chalk;
+      //build up the chalk function
+      configInput.colors[color].forEach(function(style) {
+  			colorFunc = colorFunc[style];
+  		});
+  		chalkColors[color] = colorFunc;
+  	}
+  }
+  return chalkColors;
+}
+
+var configInput = require("./lmeDefaultConfig.json");
+try {
+	// try to get the config file from root file of the application.
+	var providedConfig = require('app-root-path').require("lmeconfig.json");
+  configInput.colors = Object.assign({}, configInput.colors, providedConfig.colors);
+} catch (e) {
+	//it is okay if no override file is provided
+}
+
+configInput.colors = getChalkColors(configInput);
+module.exports = configInput;

--- a/index.js
+++ b/index.js
@@ -1,33 +1,8 @@
 'use strict';
 
-var chalk = require('chalk');
 var logUtil = require('./logUtil');
 var linesUtil = require('./linesUtil');
-
-// configuration variable
-var config;
-
-try {
-	// try to get the config file from root file of the application.
-	config = require('app-root-path').require("lmeconfig.json");
-} catch (e) {
-	// delete the line below before publishing <<<<<<<<<<<<<<<<<<
-	console.log("Since local config is not found in the app-root-path, lme is using the default config. [need to delete this output before publishing.]")
-
-	// if it fails use the default configuration provided with this package.
-	config = require("./lmeDefaultConfig.json");
-}
-
-// make the read file understandable to chalk.
-for (var i in config.colors) {
-	if (config.colors.hasOwnProperty(i)) {
-		var temp = chalk;
-		config.colors[i].forEach(function(style) {
-			temp = temp[style];
-		});
-		config.colors[i] = temp;
-	}
-}
+var config = require('./config');
 
 var m = {
 	//////////////////

--- a/index.js
+++ b/index.js
@@ -1,93 +1,96 @@
 'use strict';
+
 var chalk = require('chalk');
 var logUtil = require('./logUtil');
 var linesUtil = require('./linesUtil');
-var extend = require('util')._extend;
 
-var defaultColors = {
-	d: chalk.white,
-	s: chalk.bold.green,
-	w: chalk.bgYellow.black,
-	e: chalk.bgRed.white,
-	h: chalk.bgCyan.black,
-	i: chalk.bold.cyan,
-	t: chalk.green
-};
+// configuration variable
+var config;
 
-function moduleSetup(colors) {
-	return {
-		//////////////////
-		// main methods //
-		//////////////////
+try {
+	// try to get the config file from root file of the application.
+	config = require('app-root-path').require("lmeconfig.json");
+} catch (e) {
+	// delete the line below before publishing <<<<<<<<<<<<<<<<<<
+	console.log("Since local config is not found in the app-root-path, lme is using the default config. [need to delete this output before publishing.]")
 
-		// default
-		d: function(msg) {
-			logUtil.logWithColor(colors.d, msg);
-		},
-		// success
-		s: function(msg) {
-			logUtil.logWithColor(colors.s, msg);
-		},
-		// warning
-		w: function(msg) {
-			logUtil.logWithColor(colors.w, msg);
-		},
-		// err
-		e: function(msg) {
-			logUtil.logWithColor(colors.e, msg);
-		},
-		// highlight
-		h: function(msg) {
-			logUtil.logWithColor(colors.h, msg);
-		},
-		//info
-		i: function(msg) {
-			logUtil.logWithColor(colors.i, msg);
-		},
-		//trace:
-		t: function(msg) {
-			logUtil.logTraceWithColor(colors.t, msg);
-		},
+	// if it fails use the default configuration provided with this package.
+	config = require("./lmeDefaultConfig.json");
+}
 
-		///////////
-		// lines //
-		///////////
-
-		// default
-		line: function(char, length) {
-			linesUtil.logLine(char, length, this.e, this.w);
-		},
-		// default - another
-		dline: function(char, length) {
-			linesUtil.logLine(char, length, this.e, this.w);
-		},
-		// success
-		sline: function(char, length) {
-			linesUtil.logLine(char, length, this.e, this.w, colors.s);
-		},
-		// warning
-		wline: function(char, length) {
-			linesUtil.logLine(char, length, this.e, this.w, colors.w);
-		},
-		// error
-		eline: function(char, length) {
-			linesUtil.logLine(char, length, this.e, this.w, colors.e);
-		},
-		// highlight
-		hline: function(char, length) {
-			linesUtil.logLine(char, length, this.e, this.w, colors.h);
-		}
+// make the read file understandable to chalk.
+for (var i in config.colors) {
+	if (config.colors.hasOwnProperty(i)) {
+		var temp = chalk;
+		config.colors[i].forEach(function(style) {
+			temp = temp[style];
+		});
+		config.colors[i] = temp;
 	}
 }
 
-function customColors(options) {
-	//lets use the default colors, unless otherwise specified (options override)
-	var colors = extend(defaultColors, options);
-	return moduleSetup(colors);
-}
+var m = {
+	//////////////////
+	// main methods //
+	//////////////////
 
-//need to make a clone of defaultColors, otherwise customColors might override it.
-var m = moduleSetup(extend({}, defaultColors));
-m.customColors = customColors;
+	// default
+	d: function(msg) {
+		logUtil.logWithColor(config.colors.default, msg);
+	},
+	// success
+	s: function(msg) {
+		logUtil.logWithColor(config.colors.success, msg);
+	},
+	// warning
+	w: function(msg) {
+		logUtil.logWithColor(config.colors.warning, msg);
+	},
+	// err
+	e: function(msg) {
+		logUtil.logWithColor(config.colors.error, msg);
+	},
+	// highlight
+	h: function(msg) {
+		logUtil.logWithColor(config.colors.highlight, msg);
+	},
+	//info
+	i: function(msg) {
+		logUtil.logWithColor(config.colors.info, msg);
+	},
+	//trace:
+	t: function(msg) {
+		logUtil.logTraceWithColor(config.colors.trace, msg);
+	},
+
+	///////////
+	// lines //
+	///////////
+
+	// default
+	line: function(char, length) {
+		linesUtil.logLine(char, length, this.e, this.w);
+	},
+	// default - another
+	dline: function(char, length) {
+		linesUtil.logLine(char, length, this.e, this.w);
+	},
+	// success
+	sline: function(char, length) {
+		linesUtil.logLine(char, length, this.e, this.w, config.colors.success);
+	},
+	// warning
+	wline: function(char, length) {
+		linesUtil.logLine(char, length, this.e, this.w, config.colors.warning);
+	},
+	// error
+	eline: function(char, length) {
+		linesUtil.logLine(char, length, this.e, this.w, config.colors.error);
+	},
+	// highlight
+	hline: function(char, length) {
+		linesUtil.logLine(char, length, this.e, this.w, config.colors.highlight);
+	}
+}
 
 module.exports = m;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 var chalk = require('chalk');
 var logUtil = require('./logUtil');
 var linesUtil = require('./linesUtil');
-var extend = require('util')._extend;
 
 var defaultColors = {
 	d: chalk.white,
@@ -82,12 +81,12 @@ function moduleSetup(colors) {
 
 function customColors(options) {
 	//lets use the default colors, unless otherwise specified (options override)
-	var colors = extend(defaultColors, options);
+	var colors = Object.assign({}, defaultColors, options);
 	return moduleSetup(colors);
 }
 
 //need to make a clone of defaultColors, otherwise customColors might override it.
-var m = moduleSetup(extend({}, defaultColors));
+var m = moduleSetup(Object.assign({}, defaultColors));
 m.customColors = customColors;
 
 module.exports = m;

--- a/index.js
+++ b/index.js
@@ -81,11 +81,12 @@ function moduleSetup(colors) {
 }
 
 function customColors(options) {
-  //lets use the default colors, unless otherwise specified (options override)
+	//lets use the default colors, unless otherwise specified (options override)
 	var colors = extend(defaultColors, options);
 	return moduleSetup(colors);
 }
 
+//need to make a clone of defaultColors, otherwise customColors might override it.
 var m = moduleSetup(extend({}, defaultColors));
 m.customColors = customColors;
 

--- a/index.js
+++ b/index.js
@@ -1,71 +1,92 @@
 'use strict';
-
 var chalk = require('chalk');
 var logUtil = require('./logUtil');
 var linesUtil = require('./linesUtil');
+var extend = require('util')._extend;
 
-var m = {
-	//////////////////
-	// main methods //
-	//////////////////
-
-	// default
-	d: function(msg) {
-		logUtil.logWithColor(chalk.white, msg);
-	},
-	// success
-	s: function(msg) {
-		logUtil.logWithColor(chalk.bold.green, msg);
-	},
-	// warning
-	w: function(msg) {
-		logUtil.logWithColor(chalk.bgYellow.black, msg);
-	},
-	// err
-	e: function(msg) {
-		logUtil.logWithColor(chalk.bgRed.white, msg);
-	},
-	// highlight
-	h: function(msg) {
-		logUtil.logWithColor(chalk.bgCyan.black, msg);
-	},
-	//info
-	i: function(msg) {
-		logUtil.logWithColor(chalk.bold.cyan, msg);
-	},
-	//trace:
-	t: function(msg) {
-		logUtil.logTraceWithColor(chalk.green, msg);
-	},
-
-	///////////
-	// lines //
-	///////////
-
-	// default
-	line: function(char, length) {
-		linesUtil.logLine(char, length, this.e, this.w);
-	},
-	// default - another
-	dline: function(char, length) {
-		linesUtil.logLine(char, length, this.e, this.w);
-	},
-	// success
-	sline: function(char, length) {
-		linesUtil.logLine(char, length, this.e, this.w, chalk.bold.green);
-	},
-	// warning
-	wline: function(char, length) {
-		linesUtil.logLine(char, length, this.e, this.w, chalk.bgYellow.black);
-	},
-	// error
-	eline: function(char, length) {
-		linesUtil.logLine(char, length, this.e, this.w, chalk.bgRed.white);
-	},
-	// highlight
-	hline: function(char, length) {
-		linesUtil.logLine(char, length, this.e, this.w, chalk.bgCyan.black);
-	}
+var defaultColors = {
+	d: chalk.white,
+	s: chalk.bold.green,
+	w: chalk.bgYellow.black,
+	e: chalk.bgRed.white,
+	h: chalk.bgCyan.black,
+	i: chalk.bold.cyan,
+	t: chalk.green
 };
+
+function moduleSetup(colors) {
+	return {
+		//////////////////
+		// main methods //
+		//////////////////
+
+		// default
+		d: function(msg) {
+			logUtil.logWithColor(colors.d, msg);
+		},
+		// success
+		s: function(msg) {
+			logUtil.logWithColor(colors.s, msg);
+		},
+		// warning
+		w: function(msg) {
+			logUtil.logWithColor(colors.w, msg);
+		},
+		// err
+		e: function(msg) {
+			logUtil.logWithColor(colors.e, msg);
+		},
+		// highlight
+		h: function(msg) {
+			logUtil.logWithColor(colors.h, msg);
+		},
+		//info
+		i: function(msg) {
+			logUtil.logWithColor(colors.i, msg);
+		},
+		//trace:
+		t: function(msg) {
+			logUtil.logTraceWithColor(colors.t, msg);
+		},
+
+		///////////
+		// lines //
+		///////////
+
+		// default
+		line: function(char, length) {
+			linesUtil.logLine(char, length, this.e, this.w);
+		},
+		// default - another
+		dline: function(char, length) {
+			linesUtil.logLine(char, length, this.e, this.w);
+		},
+		// success
+		sline: function(char, length) {
+			linesUtil.logLine(char, length, this.e, this.w, colors.s);
+		},
+		// warning
+		wline: function(char, length) {
+			linesUtil.logLine(char, length, this.e, this.w, colors.w);
+		},
+		// error
+		eline: function(char, length) {
+			linesUtil.logLine(char, length, this.e, this.w, colors.e);
+		},
+		// highlight
+		hline: function(char, length) {
+			linesUtil.logLine(char, length, this.e, this.w, colors.h);
+		}
+	}
+}
+
+function customColors(options) {
+  //lets use the default colors, unless otherwise specified (options override)
+	var colors = extend(defaultColors, options);
+	return moduleSetup(colors);
+}
+
+var m = moduleSetup(extend({}, defaultColors));
+m.customColors = customColors;
 
 module.exports = m;

--- a/lmeDefaultConfig.json
+++ b/lmeDefaultConfig.json
@@ -1,0 +1,11 @@
+{
+	"colors": {
+		"default": ["white"],
+		"success": ["bold", "green"],
+		"warning": ["bgYellow", "black"],
+		"error": ["bgRed", "white"],
+		"highlight": ["bgCyan", "black"],
+		"info": ["bold", "cyan"],
+		"trace": ["green"]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "homepage": "https://github.com/vajahath/lme#readme",
   "dependencies": {
+    "app-root-path": "^2.0.1",
     "chalk": "^1.1.3"
   },
   "contributors": [
     "Derek MacDonald (https://github.com/demacdonald)",
     "Aman Mittal (https://github.com/amandeepmittal)"
   ]
-
 }

--- a/test.js
+++ b/test.js
@@ -9,10 +9,6 @@ node test.js
 */
 
 const lme = require('./index');
-var chalk = require('chalk');
-
-var newColors = {i: chalk.bgRed.white};
-const lmeColors = lme.customColors(newColors);
 
 // objects
 lme.d({ kity: "is pinky", fluffy: "is funny!" });
@@ -62,6 +58,4 @@ lme.wline({ yu: 1 });
 lme.eline({ yu: 1 });
 lme.hline({ yu: 1 });
 
-lmeColors.h('should use default highlight color');
-lmeColors.i('This color should be different than below.');
 lme.i('test finished');

--- a/test.js
+++ b/test.js
@@ -9,6 +9,10 @@ node test.js
 */
 
 const lme = require('./index');
+var chalk = require('chalk');
+
+var newColors = {i: chalk.bgRed.white};
+const lmeColors = lme.customColors(newColors);
 
 // objects
 lme.d({ kity: "is pinky", fluffy: "is funny!" });
@@ -58,4 +62,6 @@ lme.wline({ yu: 1 });
 lme.eline({ yu: 1 });
 lme.hline({ yu: 1 });
 
+lmeColors.h('should use default highlight color');
+lmeColors.i('This color should be different than below.');
 lme.i('test finished');


### PR DESCRIPTION
Thought this would be a nice feature.
People can now provide alternate color schemes than the default.

instead of:
```
var lme = require('lme');
lme.i('log'); //log is using chalk.bold.cyan
lme.e('log'); //log is using default color: chalk.bgRed.white
```

People can do:
```
var someColorOverrides = {i: chalk.green}
var lme = require('lme').customColors(someColorOverrides);
lme.i('log'); //log is using chalk.green
lme.e('log'); //log is using default color: chalk.bgRed.white
```

**Note:** I did not update docs, as I am not sure if you care for this change at all.